### PR TITLE
feat: update agent config

### DIFF
--- a/config/agent-local.yml
+++ b/config/agent-local.yml
@@ -287,7 +287,7 @@ agent:
         - $require: "@veramo/did-comm#DIDComm"
         - $require: '@veramo/credential-w3c#CredentialPlugin'
         - $ref: /credentialIssuerLD
-        - require: "@veramo/credential-eip712#CredentialIssuerEIP712"
+        - $require: "@veramo/credential-eip712#CredentialIssuerEIP712"
         - $require: "@veramo/selective-disclosure#SelectiveDisclosure"
         - $require: "@veramo/data-store#DataStore"
           $args:

--- a/config/agent-local.yml
+++ b/config/agent-local.yml
@@ -20,6 +20,7 @@ constants:
     - didManagerGetProviders
     - didManagerFind
     - didManagerGet
+    - didManagerGetByAlias
     - didManagerCreate
     - didManagerGetOrCreate
     - didManagerImport
@@ -98,7 +99,8 @@ server:
     - - /messaging
       - $require: "@veramo/remote-server?t=function#MessagingRouter"
         $args:
-          - metaData:
+          - save: true
+            metaData:
               type: DIDComm
               value: https
 
@@ -285,6 +287,7 @@ agent:
         - $require: "@veramo/did-comm#DIDComm"
         - $require: '@veramo/credential-w3c#CredentialPlugin'
         - $ref: /credentialIssuerLD
+        - require: "@veramo/credential-eip712#CredentialIssuerEIP712"
         - $require: "@veramo/selective-disclosure#SelectiveDisclosure"
         - $require: "@veramo/data-store#DataStore"
           $args:

--- a/config/agent.yml
+++ b/config/agent.yml
@@ -30,6 +30,7 @@ constants:
     - didManagerGetProviders
     - didManagerFind
     - didManagerGet
+    - didManagerGetByAlias
     - didManagerCreate
     - didManagerGetOrCreate
     - didManagerImport
@@ -111,7 +112,8 @@ server:
     - - /messaging
       - $require: "@veramo/remote-server?t=function#MessagingRouter"
         $args:
-          - metaData:
+          - save: true
+            metaData:
               type: DIDComm
               value: https
 
@@ -303,6 +305,7 @@ agent:
         - $require: "@veramo/did-comm#DIDComm"
         - $require: '@veramo/credential-w3c#CredentialPlugin'
         - $ref: /credentialIssuerLD
+        - require: "@veramo/credential-eip712#CredentialIssuerEIP712"
         - $require: "@veramo/selective-disclosure#SelectiveDisclosure"
         - $require: "@veramo/data-store#DataStore"
           $args:

--- a/config/agent.yml
+++ b/config/agent.yml
@@ -305,7 +305,7 @@ agent:
         - $require: "@veramo/did-comm#DIDComm"
         - $require: '@veramo/credential-w3c#CredentialPlugin'
         - $ref: /credentialIssuerLD
-        - require: "@veramo/credential-eip712#CredentialIssuerEIP712"
+        - $require: "@veramo/credential-eip712#CredentialIssuerEIP712"
         - $require: "@veramo/selective-disclosure#SelectiveDisclosure"
         - $require: "@veramo/data-store#DataStore"
           $args:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "yarn veramo server --config=./config/agent-local.yml"
   },
   "dependencies": {
-    "@veramo/cli": "^4.1.1",
+    "@veramo/cli": "^4.1.3-next.9",
     "agent-explore": "^1.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -78,7 +78,7 @@
     fast-text-encoding "^1.0.3"
     isomorphic-webcrypto "^2.3.8"
 
-"@digitalcredentials/vc@^4.2.0":
+"@digitalcredentials/vc@^4.0.0":
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@digitalcredentials/vc/-/vc-4.2.0.tgz#d2197b26547d670965d5969a9e49437f244b5944"
   integrity sha512-8Rxpn77JghJN7noBQdcMuzm/tB8vhDwPoFepr3oGd5w+CyJxOk2RnBlgIGlAAGA+mALFWECPv1rANfXno+hdjA==
@@ -86,6 +86,20 @@
     "@digitalcredentials/jsonld" "^5.2.1"
     "@digitalcredentials/jsonld-signatures" "^9.3.1"
     credentials-context "^2.0.0"
+
+"@ethereumjs/rlp@^4.0.0-beta.2":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/rlp/-/rlp-4.0.0.tgz#66719891bd727251a7f233f9ca80212d1994f8c8"
+  integrity sha512-LM4jS5n33bJN60fM5EC8VeyhUgga6/DjCPBV2vWjnfVtobqtOiNC4SQ1MRFqyBSmJGGdB533JZWewyvlcdJtkQ==
+
+"@ethereumjs/util@^8.0.0":
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/util/-/util-8.0.2.tgz#b7348fc7253649b0f00685a94546c6eee1fad819"
+  integrity sha512-b1Fcxmq+ckCdoLPhVIBkTcH8szigMapPuEmD8EDakvtI5Na5rzmX1sBW73YQqaPc7iUxGCAzZP1LrFQ7aEMugA==
+  dependencies:
+    "@ethereumjs/rlp" "^4.0.0-beta.2"
+    async "^3.2.4"
+    ethereum-cryptography "^1.1.2"
 
 "@ethersproject/abi@^5.6.3":
   version "5.6.4"
@@ -150,6 +164,17 @@
     "@ethersproject/logger" "^5.6.0"
     "@ethersproject/properties" "^5.6.0"
 
+"@ethersproject/address@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
+  integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+
 "@ethersproject/address@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.6.1.tgz#ab57818d9aefee919c5721d28cd31fd95eff413d"
@@ -202,6 +227,15 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/properties" "^5.7.0"
 
+"@ethersproject/bignumber@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.5.0.tgz#875b143f04a216f4f8b96245bde942d42d279527"
+  integrity sha512-6Xytlwvy6Rn3U3gKEc1vP7nR92frHkv6wtVr95LFR3jREXiCPzdWxKQ1cx4JGQBXxcguAwjA8murlYN2TSiEbg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    bn.js "^4.11.9"
+
 "@ethersproject/bignumber@^5.6.2":
   version "5.6.2"
   resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.6.2.tgz#72a0717d6163fab44c47bcc82e0c550ac0315d66"
@@ -220,6 +254,13 @@
     "@ethersproject/logger" "^5.7.0"
     bn.js "^5.2.1"
 
+"@ethersproject/bytes@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
+  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/bytes@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.6.1.tgz#24f916e411f82a8a60412344bf4a813b917eefe7"
@@ -233,6 +274,13 @@
   integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
   dependencies:
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/constants@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
+  integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
+  dependencies:
+    "@ethersproject/bignumber" "^5.5.0"
 
 "@ethersproject/constants@^5.6.1":
   version "5.6.1"
@@ -330,6 +378,14 @@
     aes-js "3.0.0"
     scrypt-js "3.0.1"
 
+"@ethersproject/keccak256@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
+  integrity sha512-5VoFCTjo2rYbBe1l2f4mccaRFN/4VQEYFwwn04aJV2h7qf4ZvI2wFxUE1XOX+snbwCLRzIeikOqtAoPwMza9kg==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/keccak256@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.6.1.tgz#b867167c9b50ba1b1a92bccdd4f2d6bd168a91cc"
@@ -345,6 +401,11 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     js-sha3 "0.8.0"
+
+"@ethersproject/logger@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
+  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
 "@ethersproject/logger@^5.6.0":
   version "5.6.0"
@@ -377,6 +438,13 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/sha2" "^5.7.0"
+
+"@ethersproject/properties@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
+  integrity sha512-l3zRQg3JkD8EL3CPjNK5g7kMx4qSwiR60/uk5IVjd3oq1MZR5qUg40CNOoEJoX5wc3DyY5bt9EbMk86C7x0DNA==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
 
 "@ethersproject/properties@^5.6.0":
   version "5.6.0"
@@ -460,6 +528,14 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
 
+"@ethersproject/rlp@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.5.0.tgz#530f4f608f9ca9d4f89c24ab95db58ab56ab99a0"
+  integrity sha512-hLv8XaQ8PTI9g2RHoQGf/WSxBfTB/NudRacbzdxmst5VHAqd1sMibWG7SENzT5Dj3yZ3kJYx+WiRYEcQTAkcYA==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/rlp@^5.6.1":
   version "5.6.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.6.1.tgz#df8311e6f9f24dcb03d59a2bac457a28a4fe2bd8"
@@ -492,6 +568,18 @@
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.5.0.tgz#2aa37169ce7e01e3e80f2c14325f624c29cedbe0"
+  integrity sha512-5VmseH7qjtNmDdZBswavhotYbWB0bOwKIlOTSlX14rKn5c11QmJwGt4GHeo7NrL/Ycl7uo9AHvEqs5xZgFBTng==
+  dependencies:
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    bn.js "^4.11.9"
+    elliptic "6.5.4"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@^5.6.2":
@@ -535,6 +623,21 @@
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/constants" "^5.7.0"
     "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/transactions@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
+  integrity sha512-9RZYSKX26KfzEd/1eqvv8pLauCKzDTub0Ko4LfIgaERvRuwyaNV78mJs7cpIgZaDl6RJui4o49lHwwCM0526zA==
+  dependencies:
+    "@ethersproject/address" "^5.5.0"
+    "@ethersproject/bignumber" "^5.5.0"
+    "@ethersproject/bytes" "^5.5.0"
+    "@ethersproject/constants" "^5.5.0"
+    "@ethersproject/keccak256" "^5.5.0"
+    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/rlp" "^5.5.0"
+    "@ethersproject/signing-key" "^5.5.0"
 
 "@ethersproject/transactions@^5.6.2":
   version "5.6.2"
@@ -640,6 +743,18 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@metamask/eth-sig-util@^5.0.0":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@metamask/eth-sig-util/-/eth-sig-util-5.0.2.tgz#c518279a6e17a88135a13d53a0b970f145ff8bce"
+  integrity sha512-RU6fG/H6/UlBol221uBkq5C7w3TwLK611nEZliO2u+kO0vHKGBXnIPlhI0tzKUigjhUeOd9mhCNbNvhh0LKt9Q==
+  dependencies:
+    "@ethereumjs/util" "^8.0.0"
+    bn.js "^4.11.8"
+    ethereum-cryptography "^1.1.2"
+    ethjs-util "^0.1.6"
+    tweetnacl "^1.0.3"
+    tweetnacl-util "^0.15.1"
+
 "@microsoft/api-extractor-model@7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@microsoft/api-extractor-model/-/api-extractor-model-7.18.0.tgz#23bfe8fee6534e086ddaff4daa5b9e2d27192e09"
@@ -686,6 +801,21 @@
   version "4.0.1"
   resolved "https://registry.npmjs.org/@multiformats/base-x/-/base-x-4.0.1.tgz#95ff0fa58711789d53aefb2590a8b7a4e715d121"
   integrity sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==
+
+"@noble/hashes@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.2.tgz#e9e035b9b166ca0af657a7848eb2718f0f22f183"
+  integrity sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==
+
+"@noble/hashes@~1.1.1":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.1.3.tgz#360afc77610e0a61f3417e497dcf36862e4f8111"
+  integrity sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==
+
+"@noble/secp256k1@1.6.3", "@noble/secp256k1@~1.6.0":
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/@noble/secp256k1/-/secp256k1-1.6.3.tgz#7eed12d9f4404b416999d0c87686836c4c5c9b94"
+  integrity sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -804,6 +934,28 @@
     argparse "~1.0.9"
     colors "~1.2.1"
     string-argv "~0.3.1"
+
+"@scure/base@~1.1.0":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.1.tgz#ebb651ee52ff84f420097055f4bf46cfba403938"
+  integrity sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==
+
+"@scure/bip32@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip32/-/bip32-1.1.0.tgz#dea45875e7fbc720c2b4560325f1cf5d2246d95b"
+  integrity sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==
+  dependencies:
+    "@noble/hashes" "~1.1.1"
+    "@noble/secp256k1" "~1.6.0"
+    "@scure/base" "~1.1.0"
+
+"@scure/bip39@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@scure/bip39/-/bip39-1.1.0.tgz#92f11d095bae025f166bef3defcc5bf4945d419a"
+  integrity sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==
+  dependencies:
+    "@noble/hashes" "~1.1.1"
+    "@scure/base" "~1.1.0"
 
 "@sqltools/formatter@^1.2.2":
   version "1.2.3"
@@ -1083,10 +1235,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@transmute/credentials-context@^0.7.0-unstable.67", "@transmute/credentials-context@^0.7.0-unstable.70":
-  version "0.7.0-unstable.70"
-  resolved "https://registry.yarnpkg.com/@transmute/credentials-context/-/credentials-context-0.7.0-unstable.70.tgz#30c8a8050b5c99825f4691e665b5746066ee5f79"
-  integrity sha512-+pvqn60dLlvh9SccOFXov9agliGgp26qmrHeK+nRhLBchEfvqQv46FTtRPusxym3ccUTCQuH6++S3SFccGqZiw==
+"@transmute/credentials-context@^0.7.0-unstable.60":
+  version "0.7.0-unstable.66"
+  resolved "https://registry.yarnpkg.com/@transmute/credentials-context/-/credentials-context-0.7.0-unstable.66.tgz#4d13b894cfdf5625c647336eb2683418842a6133"
+  integrity sha512-1BGoZ+nbApiNI1NcCxL8aBWFYNtMkT+Z8xUm3lS0cmw0K5OiS9YdcRPjM59fZgcgndtqlnoKkAeS/iAdJU72nQ==
 
 "@transmute/did-context@^0.6.1-unstable.25", "@transmute/did-context@^0.6.1-unstable.36":
   version "0.6.1-unstable.37"
@@ -1146,21 +1298,20 @@
     "@transmute/ld-key-pair" "^0.6.1-unstable.37"
     "@transmute/x25519-key-pair" "^0.6.1-unstable.37"
 
-"@transmute/ed25519-signature-2018@^0.7.0-unstable.67":
-  version "0.7.0-unstable.70"
-  resolved "https://registry.yarnpkg.com/@transmute/ed25519-signature-2018/-/ed25519-signature-2018-0.7.0-unstable.70.tgz#1fd5f1a9b8d9c83c32a0ea39313b67d908ee31a1"
-  integrity sha512-/MniA8XXxe7kR7l+lp6gVjfiQ9oZHXMYuHYB+eU/9zCQXdKsZpCG8itL4syPV92xfVR70HvR8XFgpLqqETTNFg==
+"@transmute/ed25519-signature-2018@^0.7.0-unstable.60":
+  version "0.7.0-unstable.66"
+  resolved "https://registry.yarnpkg.com/@transmute/ed25519-signature-2018/-/ed25519-signature-2018-0.7.0-unstable.66.tgz#686db194e875bfee853e54d7deab3d6c71657952"
+  integrity sha512-rZgGKVgvzj+3Yq7yfcRFrPpevb1+lYEZWiB4uJs3np40ARl1jhIYFg/fJTwb5oENBR+GUrQzSpobNp2NocJ0tw==
   dependencies:
-    "@transmute/credentials-context" "^0.7.0-unstable.70"
     "@transmute/ed25519-key-pair" "0.7.0-unstable.2"
-    "@transmute/jose-ld" "^0.7.0-unstable.70"
-    "@transmute/security-context" "^0.7.0-unstable.70"
+    "@transmute/jose-ld" "^0.7.0-unstable.66"
+    "@transmute/security-context" "^0.7.0-unstable.66"
     jsonld "^5.2.0"
 
-"@transmute/jose-ld@^0.7.0-unstable.70":
-  version "0.7.0-unstable.70"
-  resolved "https://registry.yarnpkg.com/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.70.tgz#1f3ae442d2014f29170310c1035032cc06496f9d"
-  integrity sha512-PCxwMzsuFl39kiKM6+TlUCdIGjcXV6Zqi5iNA+g4Et4/LhjXVQCC4eD6DRPHJnLfGW2LxnMOUPfGg4KV1hZzOg==
+"@transmute/jose-ld@^0.7.0-unstable.66":
+  version "0.7.0-unstable.66"
+  resolved "https://registry.yarnpkg.com/@transmute/jose-ld/-/jose-ld-0.7.0-unstable.66.tgz#35f24b09a68025a6a17cce439263316cd9aa19ee"
+  integrity sha512-75TuHj/w83y1aNPnj9TXeRggaYrx44W3FF9lD2lvL4NDQj6TIRa5Sxjies8rC4yoBsq/PdcHwelUTZfpQK0qhw==
   dependencies:
     "@peculiar/webcrypto" "^1.1.6"
     "@stablelib/aes-kw" "^1.0.0"
@@ -1198,10 +1349,10 @@
   resolved "https://registry.yarnpkg.com/@transmute/security-context/-/security-context-0.6.1-unstable.37.tgz#532b9238efd80dbaaa3e7dd663107cd925afadcc"
   integrity sha512-GtLmG65qlORrz/2S4I74DT+vA4+qXsFxrMr0cNOXjUqZBd/AW1PTrFnryLF9907BfoiD58HC9qb1WVGWjSlBYw==
 
-"@transmute/security-context@^0.7.0-unstable.70":
-  version "0.7.0-unstable.70"
-  resolved "https://registry.yarnpkg.com/@transmute/security-context/-/security-context-0.7.0-unstable.70.tgz#d57aa0d6f2dd45986eaf07a31e27e5a027248c05"
-  integrity sha512-9I1687MlnrN0iy85UXD13AiFW09H9d5fKHxSTRIh0Nf79h9V023er7Qegb5pSvlZzi7q1f1JdgiAYyYiv55Ufg==
+"@transmute/security-context@^0.7.0-unstable.66":
+  version "0.7.0-unstable.66"
+  resolved "https://registry.yarnpkg.com/@transmute/security-context/-/security-context-0.7.0-unstable.66.tgz#440c212210a98ca3334b81008761c0604edf1b16"
+  integrity sha512-HxnnwvZmsBew47NlXmlzcD5Yw6+Gt8pPDTLvoHcY2/x44jkpqmm/RgfB9AMoML1nvcUdpI3zpOF5W/6W51W79g==
 
 "@transmute/x25519-key-pair@^0.6.1-unstable.37":
   version "0.6.1-unstable.37"
@@ -1348,7 +1499,7 @@
     expo-modules-autolinking "^0.0.3"
     invariant "^2.2.4"
 
-"@veramo-community/lds-ecdsa-secp256k1-recovery2020@github:uport-project/EcdsaSecp256k1RecoverySignature2020":
+"@veramo-community/lds-ecdsa-secp256k1-recovery2020@uport-project/EcdsaSecp256k1RecoverySignature2020":
   version "0.0.8"
   resolved "https://codeload.github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/tar.gz/ab0db52de6f4e6663ef271a48009ba26e688ef9b"
   dependencies:
@@ -1361,34 +1512,35 @@
     crypto-ld "^7.0.0"
     json-stringify-deterministic "^1.0.7"
 
-"@veramo/cli@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/cli/-/cli-4.1.1.tgz#ba4af25ccddb7f535c5604267216ea057f41c205"
-  integrity sha512-+1H5suBUW8j1o3G0vbNWexCIWnZaYpMmokWlGmZPAm2FqQrYWRAc4KUpWjmFw/hcEqyITCMnbR5cS+J4Fylbbg==
+"@veramo/cli@^4.1.3-next.9":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/cli/-/cli-4.1.3-next.9.tgz#4461200a925e0186ffa9a6f8d745c834ed5fc828"
+  integrity sha512-4bLoJRzQCDt6rRZnuZY/PcRyi0SQImJ9GT4PvXicZMhaHcY9whd0PopkXgn2vGKu57HQHID9w2sr9iW4gH/I+w==
   dependencies:
     "@microsoft/api-extractor" "7.25.0"
     "@microsoft/api-extractor-model" "7.18.0"
     "@types/blessed" "^0.1.17"
     "@types/swagger-ui-express" "^4.1.3"
-    "@veramo/core" "^4.1.1"
-    "@veramo/credential-ld" "^4.1.1"
-    "@veramo/credential-w3c" "^4.1.1"
-    "@veramo/data-store" "^4.1.1"
-    "@veramo/did-comm" "^4.1.1"
-    "@veramo/did-discovery" "^4.1.1"
-    "@veramo/did-jwt" "^4.1.1"
-    "@veramo/did-manager" "^4.1.1"
-    "@veramo/did-provider-ethr" "^4.1.1"
-    "@veramo/did-provider-key" "^4.1.1"
-    "@veramo/did-provider-web" "^4.1.1"
-    "@veramo/did-resolver" "^4.1.1"
-    "@veramo/key-manager" "^4.1.1"
-    "@veramo/kms-local" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
-    "@veramo/remote-client" "^4.1.1"
-    "@veramo/remote-server" "^4.1.1"
-    "@veramo/selective-disclosure" "^4.1.1"
-    "@veramo/url-handler" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/credential-eip712" "^4.1.3-next.9+33c7ceed"
+    "@veramo/credential-ld" "^4.1.3-next.9+33c7ceed"
+    "@veramo/credential-w3c" "^4.1.3-next.9+33c7ceed"
+    "@veramo/data-store" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-comm" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-discovery" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-jwt" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-manager" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-provider-ethr" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-provider-key" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-provider-web" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-resolver" "^4.1.3-next.9+33c7ceed"
+    "@veramo/key-manager" "^4.1.3-next.9+33c7ceed"
+    "@veramo/kms-local" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
+    "@veramo/remote-client" "^4.1.3-next.9+33c7ceed"
+    "@veramo/remote-server" "^4.1.3-next.9+33c7ceed"
+    "@veramo/selective-disclosure" "^4.1.3-next.9+33c7ceed"
+    "@veramo/url-handler" "^4.1.3-next.9+33c7ceed"
     blessed "^0.1.81"
     commander "^9.0.0"
     console-table-printer "^2.10.0"
@@ -1423,10 +1575,20 @@
     ws "^8.4.0"
     yaml "^2.0.0"
 
-"@veramo/core@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/core/-/core-4.1.1.tgz#9174e94db6d80dc3645e21ea814a84a83347766b"
-  integrity sha512-gkmKhiCaop5XLa5qFqBNe38JQ3NmT/PvMQP7QMFTAmrdqIKR2upTa/ySGFaR5I53iLB039ifR59GS4WSz54mAw==
+"@veramo/core@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@veramo/core/-/core-4.0.0.tgz#587c818eab5204d17e8d8004f5f733284960985d"
+  integrity sha512-9oPW5xOPRbjqfbJBlsuhjgjKenmkJduWwWoR0jc5ViTnEeMJKokbyVD9J7E56acPLMVIoVcUqxYpkQ6W6D89xQ==
+  dependencies:
+    debug "^4.3.3"
+    did-jwt-vc "^3.1.0"
+    events "^3.2.0"
+    z-schema "^5.0.2"
+
+"@veramo/core@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/core/-/core-4.1.3-next.9.tgz#dd35cdaedce80464d59363099bc3aa419a69d69c"
+  integrity sha512-7oCOXQK1jsXQDFfAlk5dlJxF0cL9eB35wYgwUv4FtTC+RyNnEyRW6K/uVfqiF1uqzNE1H3j6d7w30O9CqdOsrg==
   dependencies:
     credential-status "^2.0.5"
     debug "^4.3.3"
@@ -1435,65 +1597,76 @@
     events "^3.2.0"
     z-schema "^5.0.2"
 
-"@veramo/credential-ld@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/credential-ld/-/credential-ld-4.1.1.tgz#c829b94ddfb1ec3a4b50db9af48257943402d30c"
-  integrity sha512-/6+P/UcdYOhi70gL2FVY2IUkoKpAxSQg9TO/wG7nFRXrSlgZaoXRxiCpcy6JpGgaaNx5KHTQyRrphqmfHC7A/g==
+"@veramo/credential-eip712@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/credential-eip712/-/credential-eip712-4.1.3-next.9.tgz#4361b16cd7678efdb41b4b5584bc7afcc1459de1"
+  integrity sha512-WabcQmrRThxIRdGYcwx72Bxienpb3KjFGYhxva4GmtlWB0OTjOQl9d7Tm6hZSPo7gXb7Ok8zLqtTPkDr9ex8eQ==
+  dependencies:
+    "@metamask/eth-sig-util" "^5.0.0"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
+    debug "^4.3.3"
+    eip-712-types-generation "^0.1.6"
+
+"@veramo/credential-ld@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/credential-ld/-/credential-ld-4.1.3-next.9.tgz#fedbb1ef1e87f7406cc489adc0e02ef76eb32ff2"
+  integrity sha512-jLl/glEwGFDBXVlcOEUgzyUV9RCksW/9+cXAC6PpLjp53ZZ+L04VDRZni8Y5lZ0ZhRvqp9ISSK10rw1cfGUMdQ==
   dependencies:
     "@digitalcredentials/jsonld" "^5.2.1"
     "@digitalcredentials/jsonld-signatures" "^9.3.1"
-    "@digitalcredentials/vc" "^4.2.0"
+    "@digitalcredentials/vc" "^5.0.0"
     "@transmute/credentials-context" "^0.7.0-unstable.67"
     "@transmute/ed25519-signature-2018" "^0.7.0-unstable.67"
     "@veramo-community/lds-ecdsa-secp256k1-recovery2020" uport-project/EcdsaSecp256k1RecoverySignature2020
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-resolver" "^4.1.1"
-    "@veramo/utils" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-resolver" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     did-resolver "^4.0.1"
     uint8arrays "^3.0.0"
 
-"@veramo/credential-w3c@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/credential-w3c/-/credential-w3c-4.1.1.tgz#615584e0edc6c76cf304b942b67936fdf6c47438"
-  integrity sha512-bZ8D6eghZ2pnmLhYRAdd+8BbZre2WdgwG7V3BywqenCCv1zA2zB98Fq2JQJz5SOz9oAAYxM17XyAvKzJHKd/cA==
+"@veramo/credential-w3c@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/credential-w3c/-/credential-w3c-4.1.3-next.9.tgz#61d0ae5827dd0ae0ac16bfd559a591bd1c5662db"
+  integrity sha512-IhTP6brgSxXD0k2DyX1rN0YDSWRHfcmmpEiV/QqWyTeFn6sSwUiYenlr25zq14so70f6iyi1fSW0WAE6IkXubA==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-jwt" "^4.1.1"
-    "@veramo/did-resolver" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
-    "@veramo/utils" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-jwt" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-resolver" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     did-jwt-vc "^3.1.0"
     did-resolver "^4.0.1"
     uint8arrays "^3.0.0"
     uuid "^9.0.0"
   optionalDependencies:
-    "@veramo/credential-ld" "^4.1.1"
+    "@veramo/credential-ld" "^4.1.3-next.9+33c7ceed"
 
-"@veramo/data-store@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/data-store/-/data-store-4.1.1.tgz#9b5ea2cbe9a234a97c5301239bd734764bbf2ad7"
-  integrity sha512-8s1U53/tG9tMleAc0+L80stjkx5tMEolRMwnzumPArHAALNttp5W2YxEff+ZVs/k40dM33Kz5AiBoa+vcdgqLQ==
+"@veramo/data-store@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/data-store/-/data-store-4.1.3-next.9.tgz#ed739674f3c818b3d14e58f5d25260a9a022318e"
+  integrity sha512-vxA/vj+Cj0OYv4HhazNn/bE13CjbGvam9qQvrYNuuJjXZQDRRELZ+vtS/RXop3mQ2siynGOLLOAfLFT66VpcPQ==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-discovery" "^4.1.1"
-    "@veramo/did-manager" "^4.1.1"
-    "@veramo/key-manager" "^4.1.1"
-    "@veramo/utils" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-discovery" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-manager" "^4.1.3-next.9+33c7ceed"
+    "@veramo/key-manager" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     typeorm "^0.3.10"
 
-"@veramo/did-comm@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-comm/-/did-comm-4.1.1.tgz#84c58bf9f73d752dddc93171335dc567e8ddb248"
-  integrity sha512-SAFgTiDuwRXm1sUqCDwOigQW5cQHVmBy7skTBvMJsXSOfBLn1iwGxgWTFf6PEU4ZPS/KQ/i3BGDxeEvnvnP4sA==
+"@veramo/did-comm@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-comm/-/did-comm-4.1.3-next.9.tgz#8c2ebcab8c5a30f94855fb719aef5f303e375996"
+  integrity sha512-xAUeQwoq/ymY+bDLJ6pCJCJ7qnZ3yjcYEDOI98hDuEBM0H2OZro6SxeZZwIqFbqppD+nYNveCuWshRJE5e0hFQ==
   dependencies:
     "@ethersproject/signing-key" "^5.7.0"
     "@stablelib/ed25519" "^1.0.2"
-    "@veramo/core" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
-    "@veramo/utils" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
     cross-fetch "^3.1.4"
     debug "^4.3.3"
     did-jwt "^6.9.0"
@@ -1501,37 +1674,37 @@
     uint8arrays "^3.0.0"
     uuid "^9.0.0"
 
-"@veramo/did-discovery@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-discovery/-/did-discovery-4.1.1.tgz#fae30b156301df7072762f0cb8e52fba391f9175"
-  integrity sha512-rmUhkO1IA5AjH5JW1In2f0BSawy/SZvhHjXtDFXomRhN0SCFW573q36E71YZstuN8P/eaOdzwA2jHQIU78KeQg==
+"@veramo/did-discovery@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-discovery/-/did-discovery-4.1.3-next.9.tgz#7593d1a66e6e03b6d93774994b9739e21f4fe219"
+  integrity sha512-cIh2EsxnL1D5Nca+/5E9KqLiE45dMsynrdm2VS6ZURKbjTIS1mTKblKvSYPOjScB6nDA5dkN2DE+HE2MWISZMw==
   dependencies:
-    "@veramo/core" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
 
-"@veramo/did-jwt@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-jwt/-/did-jwt-4.1.1.tgz#f1be943b892c72528e4f7d65cf473f1ec2e898e9"
-  integrity sha512-ISuJ9fWRMPxthwMmBgJutlR3LB3QjR2RNpgEMZcjQx3dOYOsLEmLP+8AmFuuvkkeig7tLdyThE+f2lnanm9WKw==
+"@veramo/did-jwt@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-jwt/-/did-jwt-4.1.3-next.9.tgz#cd557856ee7cdafacb341ba8fa4affbf767dea32"
+  integrity sha512-3kBahbxhf7o203AA6GvkMt8c8sgmBQXfH9obAbVnrm2IG+ZNBuUmAEef4UmJj8xoedp/DboEegVKI+40JQInwQ==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     did-jwt "^6.9.0"
     did-resolver "^4.0.1"
 
-"@veramo/did-manager@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-manager/-/did-manager-4.1.1.tgz#42c7c9f46516cef17e927346ecbf86b1aa16b48f"
-  integrity sha512-N+Oc/B/l/AW2bCRwXsqPzpwQ8ajrdF7Np4+cX3GuqK7WHcPZW3irc8IKxp4hE7IHaGVHlDKLv+yDgYmAg2Q9lA==
+"@veramo/did-manager@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-manager/-/did-manager-4.1.3-next.9.tgz#9bb7b9619dcea5c304506287069abf1f8ce90a59"
+  integrity sha512-LRadX3qx7Kjx0OnIuBpJQcSvpj/q8Rh6SSTITy7kRfEPX75YKCKQwSbT74/nNci7vunfwJ3lZjTuqJ6G5tM/JQ==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-discovery" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-discovery" "^4.1.3-next.9+33c7ceed"
 
-"@veramo/did-provider-ethr@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-provider-ethr/-/did-provider-ethr-4.1.1.tgz#7b6fd7bf90338a58f03e0180d2d0d75a3b50b6d0"
-  integrity sha512-yzgQ5/RbZdeUpOL/7PJfGos0JUksRcYOP9CXA0TUcu9JxOmLPEmd2OiP/gdPuk7hoRIY66l3x2VZYhYnE6BfWQ==
+"@veramo/did-provider-ethr@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-provider-ethr/-/did-provider-ethr-4.1.3-next.9.tgz#150c76a897f639bca17cf2389f1486bcbf769dc0"
+  integrity sha512-3LRcT6gMcLGDq9hBCc4XanTRiqV73pr88r6Z75xcxZXyolPoWsrwlVMMoJhkL7IEJ514BziA/iioZlnBOeNH/g==
   dependencies:
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/abstract-signer" "5.7.0"
@@ -1540,63 +1713,74 @@
     "@ethersproject/properties" "^5.7.0"
     "@ethersproject/signing-key" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-manager" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-manager" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
-    ethr-did "^2.3.4"
+    ethr-did "^2.3.6"
 
-"@veramo/did-provider-key@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-provider-key/-/did-provider-key-4.1.1.tgz#9f766f4beee26a90e8f0c446b4615c6226ce3f44"
-  integrity sha512-YppARbNY/ONc0AQLhhOWWd4SR+371M/keDYnOZJusJofCMe+r5IP5hedIbDrVERANN6PP4oBcN5yhvqP49AvJg==
+"@veramo/did-provider-key@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-provider-key/-/did-provider-key-4.1.3-next.9.tgz#28e0ecc9dd5fa803278045ed7b53de0526b6fe60"
+  integrity sha512-TKrjI8/WUnJGazAfwDtN4lDLTQeq51OPQsxpxwsbpl1a1roDVfcQkX7bMCgiFP1JwAdfPEKvHq3X8UFoe6XjtA==
   dependencies:
     "@transmute/did-key-ed25519" "^0.3.0-unstable.9"
     "@transmute/did-key-secp256k1" "^0.3.0-unstable.9"
     "@transmute/did-key-x25519" "^0.3.0-unstable.9"
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-manager" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-manager" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     multibase "^4.0.6"
     multicodec "^3.2.1"
 
-"@veramo/did-provider-web@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-provider-web/-/did-provider-web-4.1.1.tgz#7f78079178ac8cca8399d2a3a667e3430393da62"
-  integrity sha512-RhzFo81LgugkRho2ueckGv/yyFgYoDH4tzeGn81cy2UA/fkTV22U8aZqXXzQvXfZxE9mqo8K2qa7ubCF0l22Lw==
+"@veramo/did-provider-web@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-provider-web/-/did-provider-web-4.1.3-next.9.tgz#83696dce1bf695c84120e750b2badacf20c666a2"
+  integrity sha512-VQxW74FY9WTfmrJdepEstr9NWo3H3QxRnnbYC3OX5wDsljLvPSVVrU5XnSqlLczJANWVS+n0QMjuZL/gr8Megg==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/did-manager" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-manager" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
 
-"@veramo/did-resolver@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/did-resolver/-/did-resolver-4.1.1.tgz#1d2c749281e090d4e09afcf91770726701d5ffd6"
-  integrity sha512-TxDoCYt23r1Jf/cVdfaeqYQGHw5NbklOfv0TGY+CnUf2fQoehdlG3g6/EJ9E1y6IscFssnRU9nSowTWMrc1AuQ==
+"@veramo/did-resolver@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@veramo/did-resolver/-/did-resolver-4.0.2.tgz#f0d948fc15f60b52835c76ce019a247f8c62e119"
+  integrity sha512-J+voF6ixVL9H4czP47kndgdf50qmW1Mrp6N4iunb4CyAZfRG/KlDI4vW3/89jpDVRt1BoMr5UKKqlrozVqDSLg==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/utils" "^4.1.1"
+    "@veramo/core" "^4.0.0"
+    "@veramo/utils" "^4.0.2"
+    cross-fetch "^3.1.4"
+    debug "^4.3.3"
+    did-resolver "^4.0.0"
+
+"@veramo/did-resolver@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/did-resolver/-/did-resolver-4.1.3-next.9.tgz#7a347e82e0a2ca82c5034afe914774dc7e4e94bb"
+  integrity sha512-P19FnHMKHtv9V9sj9Kp1CeuvOE3e+E6ybQj1YsgrdvCyosqx5i1V/i1TYHvMShK+raaI3hAHBXMrrJLSmL6OPw==
+  dependencies:
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/utils" "^4.1.3-next.9+33c7ceed"
     cross-fetch "^3.1.4"
     debug "^4.3.3"
     did-resolver "^4.0.1"
 
-"@veramo/key-manager@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/key-manager/-/key-manager-4.1.1.tgz#0a9eccf0725e37cec689dc8283abdd8ae7479c20"
-  integrity sha512-dq7eeyBJ4dYn4fGzWRqdCq6fTvy3D7LD7l8d12lVFj48m3SuFCbc+zAw7RbqG2jmgQbaXoCmhzyDcJmkLqSEKg==
+"@veramo/key-manager@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/key-manager/-/key-manager-4.1.3-next.9.tgz#6f56200784e22417b7f5397a5bd82d83733ef360"
+  integrity sha512-Kgwhpplchp9EixPZjAZ3KfA4LGLJc+E2+QVn5F/zLnL+PvfLaDX/VTJrKP5XeMdI3A1OX5yXpV/eTTFV5W1IiQ==
   dependencies:
     "@ethersproject/bytes" "^5.7.0"
     "@ethersproject/strings" "^5.7.0"
     "@ethersproject/transactions" "^5.7.0"
     "@stablelib/ed25519" "^1.0.2"
-    "@veramo/core" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
     did-jwt "^6.9.0"
     uint8arrays "^3.0.0"
     uuid "^9.0.0"
 
-"@veramo/kms-local@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/kms-local/-/kms-local-4.1.1.tgz#6ac7c7a0e17b9b06943ea6bcf797fd55e1a93f8d"
-  integrity sha512-fX4f6jxjAT7df7Pm9xjwU+LQ/rv+DycfX8dz/+f8VDMyN0WYXGPWiN8xgIqeHbMwW7v3xn/xS1rcFsXPxjzPzQ==
+"@veramo/kms-local@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/kms-local/-/kms-local-4.1.3-next.9.tgz#a80ca1ba982cadc5691a70892961fc3689b6cf7b"
+  integrity sha512-J61fA/00OAIUk4DELtZPZ18iwhNoGnlF1H6BkJOCq6LVRKrNBsyMGuZD4oI2kW6AvGwTiFPZIwMRslOJCGlgww==
   dependencies:
     "@ethersproject/abstract-provider" "^5.7.0"
     "@ethersproject/bytes" "^5.7.0"
@@ -1607,76 +1791,93 @@
     "@ethersproject/wallet" "^5.7.0"
     "@stablelib/ed25519" "^1.0.2"
     "@stablelib/nacl" "^1.0.2"
-    "@veramo/core" "^4.1.1"
-    "@veramo/key-manager" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/key-manager" "^4.1.3-next.9+33c7ceed"
     base-58 "^0.0.1"
     debug "^4.3.3"
     did-jwt "^6.9.0"
     elliptic "^6.5.4"
     uint8arrays "^3.0.0"
 
-"@veramo/message-handler@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/message-handler/-/message-handler-4.1.1.tgz#ff31a80f25ee12915a8873214dd9dc043d1584b2"
-  integrity sha512-JQCiCslSIKMD3rzLAlhkM8PbuMSPP83+GvO6aA73bJCkaPu158/ZZcPz6B1HGwJx8AMxtv+SLgRpQNsAdU3ZLQ==
+"@veramo/message-handler@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/message-handler/-/message-handler-4.1.3-next.9.tgz#69c1c79f9d47af8f62dfea06f54d07758cbe3008"
+  integrity sha512-Lkgbc3H1anc9k2FVjbncyCY1fKjE8Iga+hbfY9KdWLB/z23aZQI3T/I5D459TUb/fuMRzTmRfA2QvTvlsVubNg==
   dependencies:
-    "@veramo/core" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
 
-"@veramo/remote-client@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/remote-client/-/remote-client-4.1.1.tgz#3a22c074c801d7d4db4548fb16f6f3ecd53fac1a"
-  integrity sha512-2u3KXjZr81baJSJ6+vYODeoCXKDkk+M4nJdLajkSncXX0XnmFo1lmU6zYvAoD5tqvhmzZEjUhxycskr/KaCsIQ==
+"@veramo/remote-client@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/remote-client/-/remote-client-4.1.3-next.9.tgz#cf8f8e6448621e0945ed5e398975e46e5c85cd3b"
+  integrity sha512-jS42ftp6EFodMZsi1Uvtne55vT7HcKqrJiAP53w0jj/WdYdBXC66ebsUup88p/l4DIH2X+oBM4D80cis8J5PwQ==
   dependencies:
-    "@veramo/core" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
     cross-fetch "^3.1.4"
     debug "^4.3.3"
     openapi-types "12.0.2"
 
-"@veramo/remote-server@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/remote-server/-/remote-server-4.1.1.tgz#5c3c9513cb808c0b232253eea980ae84b9a225d9"
-  integrity sha512-xcqDkoqc2Af4Fw5OZtWJsa4XYVnaJ0la/4io4lxjSG6VaHHyXmLk+rrLzoNzkIEq/+KA9fPy/h6UFLzfNGn+Rg==
+"@veramo/remote-server@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/remote-server/-/remote-server-4.1.3-next.9.tgz#5f7cc781d76aab7537fbb092c1e5eb696e5642d0"
+  integrity sha512-jb3IWXvwRCmpHCp7eipGXSPWql6wIM3B72wkPlHTJF+Q0K3z082fTcuNS9xClQ8O6Z5y+c8J8yjphuYtLM/sHw==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/remote-client" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/remote-client" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     did-resolver "^4.0.1"
     passport "^0.6.0"
     passport-http-bearer "^1.0.1"
     url-parse "^1.5.4"
 
-"@veramo/selective-disclosure@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/selective-disclosure/-/selective-disclosure-4.1.1.tgz#a74fab7672de7920083d47143e1c32fa4c736143"
-  integrity sha512-1tOgzlijtEuNOYd5o+muS3egX8CgDDHXxU/O/BhEgL8IlURQkc0wAULO+WRp3aKctgvL76mL3lKTi07u08pKgQ==
+"@veramo/selective-disclosure@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/selective-disclosure/-/selective-disclosure-4.1.3-next.9.tgz#3cb28ce2f9bb049a2cdc6038a7c7d31adbb5c615"
+  integrity sha512-OjfonZFqe6oq2qjn4qGK0pS+qc+oH6fxbJfxoNh9caQ8JVsGeHieTldProL+54B+dOSLFRdieX3ihD3tY+3cqQ==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/credential-w3c" "^4.1.1"
-    "@veramo/did-jwt" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/credential-w3c" "^4.1.3-next.9+33c7ceed"
+    "@veramo/did-jwt" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
     debug "^4.3.3"
     did-jwt "^6.9.0"
     uuid "^9.0.0"
 
-"@veramo/url-handler@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/url-handler/-/url-handler-4.1.1.tgz#8737042c53bf0b304ba26c15c0d3f40e7f1babf8"
-  integrity sha512-Opb/1k+qFH9Dgq8gWXdGNi97j13pdRD+VJqc+n85XbsnYT41jTJEcyHv9kB/toV68G1MUalC6Ah97H6OL535Yg==
+"@veramo/url-handler@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/url-handler/-/url-handler-4.1.3-next.9.tgz#bb7c0e3629dee91a6099001fc570981bd4d9323e"
+  integrity sha512-4QoedKkU3eh3b/fSuwMzFSnwD7HJ+rbf1KjfTbhiqD+fyuFdIErRU/HsgVoSgG+RAw69xQlvlKn3TMOP085jUA==
   dependencies:
-    "@veramo/core" "^4.1.1"
-    "@veramo/message-handler" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
+    "@veramo/message-handler" "^4.1.3-next.9+33c7ceed"
     cross-fetch "^3.1.4"
     debug "^4.3.3"
     url-parse "^1.5.4"
 
-"@veramo/utils@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@veramo/utils/-/utils-4.1.1.tgz#28516aee3f19d7fdf25a2244ea1e40e4c6d9de7b"
-  integrity sha512-YfPP1SrXcxf31lgDRUxF30MCn7j4/Rdk9u47VuDDD8oH+1aGTUDq2QNAl0BVcL4QImxAS1+2xm3optdFt/dNAA==
+"@veramo/utils@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@veramo/utils/-/utils-4.0.2.tgz#b518ae296f4a7b7044360c1ed7cbe45f276dfdbb"
+  integrity sha512-AWWSiCllR+yz5iUEy03W1OZA+VJiEtRkjZpSq5jTi+l3kc8IxTo6kR0r1ppKRCs5Cj32Awcapt81kFMnsVTsjQ==
+  dependencies:
+    "@ethersproject/transactions" "^5.5.0"
+    "@stablelib/ed25519" "^1.0.2"
+    "@veramo/core" "^4.0.0"
+    blakejs "^1.1.1"
+    cross-fetch "^3.1.4"
+    debug "^4.3.3"
+    did-jwt "^6.6.0"
+    did-jwt-vc "^3.1.0"
+    did-resolver "^4.0.0"
+    elliptic "^6.5.4"
+    uint8arrays "^3.0.0"
+
+"@veramo/utils@^4.1.3-next.9+33c7ceed":
+  version "4.1.3-next.9"
+  resolved "https://registry.yarnpkg.com/@veramo/utils/-/utils-4.1.3-next.9.tgz#fa9cac52eddf54f7ac0a66dd7bc48fcf13b910b8"
+  integrity sha512-iPRhGJP2j2ISImMH4xo17LkDroYnztLTbIelj16uE5K3KA+5eGT3LQTKgAp2yZZKQ/PahuDD7HfaaGM6dYd5SA==
   dependencies:
     "@ethersproject/transactions" "^5.7.0"
     "@stablelib/ed25519" "^1.0.2"
-    "@veramo/core" "^4.1.1"
+    "@veramo/core" "^4.1.3-next.9+33c7ceed"
     blakejs "^1.1.1"
     cross-fetch "^3.1.4"
     debug "^4.3.3"
@@ -1876,6 +2077,11 @@ assert-plus@1.0.0, assert-plus@^1.0.0:
   resolved "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
   integrity sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
 
+async@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
+
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -1971,7 +2177,7 @@ blessed@^0.1.81:
   resolved "https://registry.npmjs.org/blessed/-/blessed-0.1.81.tgz#f962d687ec2c369570ae71af843256e6d0ca1129"
   integrity sha1-+WLWh+wsNpVwrnGvhDJW5tDKESk=
 
-bn.js@^4.0.0, bn.js@^4.11.9:
+bn.js@^4.0.0, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
@@ -2503,6 +2709,13 @@ ee-first@1.1.1:
   resolved "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
   integrity sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=
 
+eip-712-types-generation@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/eip-712-types-generation/-/eip-712-types-generation-0.1.6.tgz#5f5d6ff57a10b00bd616acb8cabf91bcf9fa4d68"
+  integrity sha512-O2zjZcGFKyuXxW3s5ATxA1EJzszWHKYASBqpIyIhXzvFW6YFkYdDIgsoAdLnX3ClZd6908xaOPPPbTVgXy0URQ==
+  dependencies:
+    json-canonicalize "^1.0.4"
+
 elliptic@6.5.4, elliptic@^6.5.2, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
@@ -2599,7 +2812,25 @@ etag@~1.8.1:
   resolved "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=
 
-ethr-did-resolver@^7.0.1, ethr-did-resolver@^7.0.2:
+ethereum-cryptography@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz#74f2ac0f0f5fe79f012c889b3b8446a9a6264e6d"
+  integrity sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==
+  dependencies:
+    "@noble/hashes" "1.1.2"
+    "@noble/secp256k1" "1.6.3"
+    "@scure/bip32" "1.1.0"
+    "@scure/bip39" "1.1.0"
+
+ethjs-util@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/ethjs-util/-/ethjs-util-0.1.6.tgz#f308b62f185f9fe6237132fb2a9818866a5cd536"
+  integrity sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+    strip-hex-prefix "1.0.0"
+
+ethr-did-resolver@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/ethr-did-resolver/-/ethr-did-resolver-7.0.2.tgz#628f9e7f290ec563b7ce31eca27a55ae3188a755"
   integrity sha512-l4TlISn8tDtBssbxlLz0bky48aQP2k7QGXiwcU1aatqLhz6Mgau2SuCy2N6zBRBPbprkYv5rrWeReHfmegQNuw==
@@ -2617,10 +2848,10 @@ ethr-did-resolver@^7.0.1, ethr-did-resolver@^7.0.2:
     "@ethersproject/transactions" "^5.6.2"
     did-resolver "^4.0.1"
 
-ethr-did@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/ethr-did/-/ethr-did-2.3.4.tgz#1bc1b5cac72370c153a4968bfbb88dcae7dc04ae"
-  integrity sha512-W2FqYi7T0YPlODNAJJL/ENDFgUVEhUOENkKTEkV2XetbxF3Xk1Cc5o1GWiR7Tq6KrREgnWlFHtp6BIv0vEVdqw==
+ethr-did@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/ethr-did/-/ethr-did-2.3.6.tgz#567173791040291e44fd3d63cea17e7dbcea4516"
+  integrity sha512-rvDMqbnTuRqMY/2uU40IoqxN03SIqGwvjNNqxxUlr+CUaWZVgz2ZkOCygyRtTRfRLY7NAJQBFi6gXjDyBOSxrg==
   dependencies:
     "@ethersproject/abstract-signer" "^5.7.0"
     "@ethersproject/base64" "^5.7.0"
@@ -2633,7 +2864,7 @@ ethr-did@^2.3.4:
     "@ethersproject/wallet" "^5.7.0"
     did-jwt "^6.9.0"
     did-resolver "^4.0.1"
-    ethr-did-resolver "^7.0.1"
+    ethr-did-resolver "^7.0.2"
 
 event-target-shim@^5.0.0:
   version "5.0.1"
@@ -3332,6 +3563,11 @@ is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-hex-prefixed@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/is-hex-prefixed/-/is-hex-prefixed-1.0.0.tgz#7d8d37e6ad77e5d127148913c573e082d777f554"
+  integrity sha512-WvtOiug1VFrE9v1Cydwm+FnXd3+w9GaeVUss5W4v/SLy3UW00vP+6iNF2SdnfiBoLy4bTqVdkftNGTUeOFVsbA==
+
 is-interactive@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-interactive/-/is-interactive-1.0.0.tgz#cea6e6ae5c870a7b0a0004070b7b587e0252912e"
@@ -3458,6 +3694,11 @@ jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
+json-canonicalize@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/json-canonicalize/-/json-canonicalize-1.0.4.tgz#efb2d0b07df12365e39028aa70f879237ec102ea"
+  integrity sha512-YNr/ePzgReHwlnAm3EVV1pcimwesI+1DZr5v7WBKOc1zE1t7pjxWAPRxJFT3ll6flLIdRe0DPia/8cl2FLAZNA==
 
 json-schema-traverse@^0.4.1:
   version "0.4.1"
@@ -4791,6 +5032,13 @@ strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
+strip-hex-prefix@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/strip-hex-prefix/-/strip-hex-prefix-1.0.0.tgz#0c5f155fef1151373377de9dbb588da05500e36f"
+  integrity sha512-q8d4ue7JGEiVcypji1bALTos+0pWtyGlivAWyPuTkHzuTCJqrK9sWxYQZUq6Nq3cuyv3bm734IhHvHtGGURU6A==
+  dependencies:
+    is-hex-prefixed "1.0.0"
+
 strip-json-comments@~3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
@@ -4912,10 +5160,20 @@ tunnel-agent@^0.6.0:
   dependencies:
     safe-buffer "^5.0.1"
 
+tweetnacl-util@^0.15.1:
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz#b80fcdb5c97bcc508be18c44a4be50f022eea00b"
+  integrity sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==
+
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+tweetnacl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-1.0.3.tgz#ac0af71680458d8a6378d0d0d050ab1407d35596"
+  integrity sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==
 
 type-fest@^0.11.0:
   version "0.11.0"


### PR DESCRIPTION
- add didManagerGetByAlias function to list of available functions
- by default, have DIDCommMessages received by the agent saved. specify this parameter explicitly.

I understand that the 'save' parameter is deprecated, but I think this is a better UX for this "quick start" than not saving messages